### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/code/backend/app/facerecognition/routes.py
+++ b/code/backend/app/facerecognition/routes.py
@@ -15,9 +15,7 @@ aws_secret_key = os.getenv('AWS_REKOGNITION_SECRET')
 aws_region = os.getenv('AWS_REGION')
 
 # Debugging prints to verify environment variables
-print(f"AWS_ACCESS_KEY: {aws_access_key}")
-print(f"AWS_SECRET_KEY: {aws_secret_key}")
-print(f"AWS_REGION: {aws_region}")
+print("AWS credentials and region are set" if aws_access_key and aws_secret_key and aws_region else "AWS credentials and region are not set")
 
 if not aws_access_key or not aws_secret_key or not aws_region:
     raise ValueError("AWS credentials and region must be set in environment variables")


### PR DESCRIPTION
Potential fix for [https://github.com/noluchs/SEM4-EVENTGALLERY/security/code-scanning/7](https://github.com/noluchs/SEM4-EVENTGALLERY/security/code-scanning/7)

To fix the problem, we need to remove the logging of sensitive information such as AWS credentials. Instead of logging the actual values, we can log a message indicating whether the environment variables are set or not. This way, we can still have some level of debugging information without exposing sensitive data.

- Remove the lines that print the AWS credentials.
- Replace them with a message that indicates whether the credentials are set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
